### PR TITLE
 $title->mArticleID is always -1

### DIFF
--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -127,7 +127,7 @@ class SpecialOAuth2Client extends SpecialPage {
 				unset( $_SESSION['returnto'] );
 			}
 
-			if( !$title instanceof Title || 0 > $title->mArticleID ) {
+			if( !$title instanceof Title ) {
 				$title = Title::newMainPage();
 			}
 			$wgOut->redirect( $title->getFullURL() );


### PR DESCRIPTION
it seems `$title->mArticleID` is always -1, I don't know why, but this check makes a redirect to the page where the login was started fail.
